### PR TITLE
AGCAT-147: Change base images for Keycloak

### DIFF
--- a/server-x/Dockerfile
+++ b/server-x/Dockerfile
@@ -1,9 +1,9 @@
-FROM registry.access.redhat.com/ubi8-minimal AS build-env
+FROM amazoncorretto:11.0.12 AS build-env
 
 ENV KEYCLOAK_VERSION 15.0.2
 ARG KEYCLOAK_DIST=https://github.com/keycloak/keycloak/releases/download/$KEYCLOAK_VERSION/keycloak.x-preview-$KEYCLOAK_VERSION.tar.gz
 
-RUN microdnf install -y tar gzip && \
+RUN yum install -y tar gzip && \
     mkdir /opt/jboss && \ 
     cd /opt/jboss && \
     curl -L $KEYCLOAK_DIST | tar zx && \
@@ -11,13 +11,13 @@ RUN microdnf install -y tar gzip && \
     
 ADD tools /opt/jboss/tools
 
-FROM registry.access.redhat.com/ubi8-minimal
+FROM amazoncorretto:11.0.12
 
 COPY --from=build-env /opt/jboss /opt/jboss
 COPY probes /probes
 
-RUN microdnf update -y && \
-    microdnf install -y java-11-openjdk-headless && microdnf clean all && rm -rf /var/cache/yum/* && \
+RUN yum update -y && \
+    yum clean all && rm -rf /var/cache/yum/* && \
     echo "jboss:x:0:root" >> /etc/group && \
     echo "jboss:x:1000:0:JBoss user:/opt/jboss:/sbin/nologin" >> /etc/passwd && \
     chown -R jboss:root /opt/jboss && \

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8-minimal
+FROM amazoncorretto:11
 
 ENV KEYCLOAK_VERSION 15.0.2
 ENV JDBC_POSTGRES_VERSION 42.2.5
@@ -17,7 +17,7 @@ ARG KEYCLOAK_DIST=https://github.com/keycloak/keycloak/releases/download/$KEYCLO
 
 USER root
 
-RUN microdnf update -y && microdnf install -y glibc-langpack-en gzip hostname java-11-openjdk-headless openssl tar which && microdnf clean all
+RUN yum update -y && yum install -y gzip hostname openssl tar which && yum clean all
 
 ADD tools /opt/jboss/tools
 RUN /opt/jboss/tools/build-keycloak.sh


### PR DESCRIPTION
This PR modifies our fork of the Keycloak container repository to modify the server and server-x containers to be built on Amazon Corretto as a base rather than RedHat UBI.

From the readmes and configuration of the two images, it looks as though the server-x image is intended as a base image from which we can build service-specific deployments, whereas the server image is intended for developer use in a local docker container as the latter has a bundled set of scripts for interacting with the running container.

This PR hopefully addresses the first item in AGCAT-47 in that it should be possible to build and run the server image for local development work. 

NOTE: The base image used is *not* the alpine version of Corretto as this image is not available for the ARM64 architecture and so won't run on M1 Macs. We could consider using alpine as the base for the server-x image as this would be intended as the base for building an image to deploy to the cluster, but for now I've gone with the simplicity of building both with the same base Corretto image.